### PR TITLE
fix: Add default value for voting.private

### DIFF
--- a/decide/voting/models.py
+++ b/decide/voting/models.py
@@ -36,7 +36,7 @@ class Voting(models.Model):
     start_date = models.DateTimeField(blank=True, null=True)
     end_date = models.DateTimeField(blank=True, null=True)
 
-    private = models.BooleanField(help_text = 'If it is checked, the voting will be anonymous')
+    private = models.BooleanField(help_text = 'If it is checked, the voting will be anonymous', default = False)
 
     pub_key = models.OneToOneField(Key, related_name='voting', blank=True, null=True, on_delete=models.SET_NULL)
     auths = models.ManyToManyField(Auth, related_name='votings')


### PR DESCRIPTION
This adds default value to deal with votings created previously the implementation of the private field.

The issues #23 & #24 should be solved after this change.